### PR TITLE
Adapting Dockerfile best practices

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,44 +1,43 @@
-FROM ubuntu
+FROM ubuntu:16.04
 MAINTAINER helgeho@invelop.de
+
+ENV SPARK_VERSION=2.0.1 \
+    HADOOP_VERSION=2.7 \
+    ZEPPELIN_VERSION=0.6.2
 
 ENV TERM xterm
 EXPOSE 8080
-VOLUME /deps
-VOLUME /data
-VOLUME /notes
+VOLUME /deps /data /notes
 
-RUN apt-get update
-RUN apt-get install -y apt-transport-https
-
-RUN apt-get install -y openjdk-8-jdk
-RUN apt-get install -y curl
-RUN apt-get install -y wget
-RUN apt-get install -y vim
+RUN apt-get update && apt-get install -y \
+    apt-transport-https \
+    curl \
+    openjdk-8-jdk \
+    vim \
+    wget \
+  && rm -rf /var/lib/apt/lists/*
 
 # Scala and SBT
-RUN apt-get install -y scala
-RUN echo "deb https://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823
-RUN apt-get update
-RUN apt-get install -y sbt
-
-# ArchiveSpark
-RUN git clone https://github.com/helgeho/ArchiveSpark.git
-WORKDIR ArchiveSpark
-RUN sbt assemblyPackageDependency
-RUN sbt assembly
-WORKDIR /
+RUN echo "deb https://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list \
+  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823 \
+  && apt-get update && apt-get install -y scala sbt \
+  && rm -rf /var/lib/apt/lists/*
 
 # Spark
-RUN wget http://www-us.apache.org/dist/spark/spark-2.0.1/spark-2.0.1-bin-hadoop2.7.tgz
-RUN tar xfz spark-2.0.1-bin-hadoop2.7.tgz
-RUN rm spark-2.0.1-bin-hadoop2.7.tgz
+RUN wget http://www-us.apache.org/dist/spark/spark-$SPARK_VERSION/spark-$SPARK_VERSION-bin-hadoop$HADOOP_VERSION.tgz \
+  && tar xfz spark-$SPARK_VERSION-bin-hadoop$HADOOP_VERSION.tgz \
+  && rm spark-$SPARK_VERSION-bin-hadoop$HADOOP_VERSION.tgz
 
 # Zeppelin
-RUN wget http://www-us.apache.org/dist/zeppelin/zeppelin-0.6.2/zeppelin-0.6.2-bin-netinst.tgz
-RUN tar xfz zeppelin-0.6.2-bin-netinst.tgz
-RUN rm zeppelin-0.6.2-bin-netinst.tgz
-WORKDIR zeppelin-0.6.2-bin-netinst
+RUN wget http://www-us.apache.org/dist/zeppelin/zeppelin-$ZEPPELIN_VERSION/zeppelin-$ZEPPELIN_VERSION-bin-netinst.tgz \
+  && tar xfz zeppelin-$ZEPPELIN_VERSION-bin-netinst.tgz \
+  && rm zeppelin-$ZEPPELIN_VERSION-bin-netinst.tgz
+
+# ArchiveSpark
+RUN git clone https://github.com/helgeho/ArchiveSpark.git && cd ArchiveSpark \
+  && sbt assemblyPackageDependency && sbt assembly
+
+WORKDIR zeppelin-$ZEPPELIN_VERSION-bin-netinst
 
 COPY zeppelin-env.sh conf/zeppelin-env.sh.temp
 RUN tr "\r" " " < conf/zeppelin-env.sh.temp > conf/zeppelin-env.sh


### PR DESCRIPTION
Dockerfile overhauling based on the [best practices](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/). Major changes include:

* Version pinning of the base image `ubuntu:16.04` to avoid future surprises
* Added environment variables to make version bump for updates easier
* Cut down the number of layers in more than half
* Reordered the ArchiveSpark block to avoid unnecessary `WORKDIR` layer